### PR TITLE
Priority track

### DIFF
--- a/src/main/java/ti4/commands/CommandManager.java
+++ b/src/main/java/ti4/commands/CommandManager.java
@@ -120,8 +120,7 @@ public class CommandManager {
         new SelectionBoxDemoCommand(),
         new UserCommand(),
         new TIGLCommand(),
-        new OmegaPhaseCommand()
-    ).collect(Collectors.toMap(ParentCommand::getName, command -> command));
+        new OmegaPhaseCommand()).collect(Collectors.toMap(ParentCommand::getName, command -> command));
 
     public static ParentCommand getCommand(String name) {
         return commands.get(name);

--- a/src/main/java/ti4/commands/CommandManager.java
+++ b/src/main/java/ti4/commands/CommandManager.java
@@ -26,6 +26,7 @@ import ti4.commands.installation.InstallationCommand;
 import ti4.commands.leaders.LeaderCommand;
 import ti4.commands.map.MapCommand;
 import ti4.commands.milty.MiltyCommand;
+import ti4.commands.omegaphase.OmegaPhaseCommand;
 import ti4.commands.planet.PlanetCommand;
 import ti4.commands.player.PlayerCommand;
 import ti4.commands.relic.RelicCommand;
@@ -118,7 +119,8 @@ public class CommandManager {
         new PlanetCommand(),
         new SelectionBoxDemoCommand(),
         new UserCommand(),
-        new TIGLCommand()
+        new TIGLCommand(),
+        new OmegaPhaseCommand()
     ).collect(Collectors.toMap(ParentCommand::getName, command -> command));
 
     public static ParentCommand getCommand(String name) {

--- a/src/main/java/ti4/commands/omegaphase/AssignPlayerPriority.java
+++ b/src/main/java/ti4/commands/omegaphase/AssignPlayerPriority.java
@@ -13,10 +13,10 @@ class AssignPlayerPriority extends GameStateSubcommand {
     public AssignPlayerPriority() {
         super(Constants.ASSIGN_PLAYER_PRIORITY, "Assign a player's position on the Priority Track", true, true);
         addOptions(
-                new OptionData(OptionType.INTEGER, Constants.PRIORITY_POSITION, "New priority position (1 - 8)", true))
+            new OptionData(OptionType.INTEGER, Constants.PRIORITY_POSITION, "Position on priority track (assign -1 to remove them from the track)", true))
                 .addOptions(new OptionData(OptionType.USER, Constants.PLAYER, "Player for which you set stats"))
                 .addOptions(new OptionData(OptionType.STRING, Constants.FACTION_COLOR,
-                        "Set stats for another Faction or Color")
+                    "Set stats for another Faction or Color")
                         .setAutoComplete(true));
     }
 
@@ -26,8 +26,8 @@ class AssignPlayerPriority extends GameStateSubcommand {
         var player = getPlayer();
         var maxPosition = game.getPlayers().size();
         var newPosition = event.getOption(Constants.PRIORITY_POSITION, null, OptionMapping::getAsInt);
-        if (newPosition < 1 || newPosition > maxPosition) {
-            MessageHelper.sendMessageToChannel(event.getChannel(), "Priority position must be between 1 and " + maxPosition + ".");
+        if (newPosition < -1 || newPosition > maxPosition) {
+            MessageHelper.sendMessageToChannel(event.getChannel(), "Priority position must be between 1 and " + maxPosition + ", or -1 to remove them.");
             return;
         }
 

--- a/src/main/java/ti4/commands/omegaphase/AssignPlayerPriority.java
+++ b/src/main/java/ti4/commands/omegaphase/AssignPlayerPriority.java
@@ -1,0 +1,36 @@
+package ti4.commands.omegaphase;
+
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import ti4.commands.GameStateSubcommand;
+import ti4.helpers.Constants;
+import ti4.message.MessageHelper;
+import ti4.helpers.omegaPhase.PriorityTrackHelper;
+
+class AssignPlayerPriority extends GameStateSubcommand {
+    public AssignPlayerPriority() {
+        super(Constants.ASSIGN_PLAYER_PRIORITY, "Assign a player's position on the Priority Track", true, true);
+        addOptions(
+                new OptionData(OptionType.INTEGER, Constants.PRIORITY_POSITION, "New priority position (1 - 8)", true))
+                .addOptions(new OptionData(OptionType.USER, Constants.PLAYER, "Player for which you set stats"))
+                .addOptions(new OptionData(OptionType.STRING, Constants.FACTION_COLOR,
+                        "Set stats for another Faction or Color")
+                        .setAutoComplete(true));
+    }
+
+    @Override
+    public void execute(SlashCommandInteractionEvent event) {
+        var game = getGame();
+        var player = getPlayer();
+        var maxPosition = game.getPlayers().size();
+        var newPosition = event.getOption(Constants.PRIORITY_POSITION, null, OptionMapping::getAsInt);
+        if (newPosition < 1 || newPosition > maxPosition) {
+            MessageHelper.sendMessageToChannel(event.getChannel(), "Priority position must be between 1 and " + maxPosition + ".");
+            return;
+        }
+
+        PriorityTrackHelper.AssignPlayerToPriority(game, player, newPosition);
+    }
+}

--- a/src/main/java/ti4/commands/omegaphase/AssignPlayerPriority.java
+++ b/src/main/java/ti4/commands/omegaphase/AssignPlayerPriority.java
@@ -11,9 +11,9 @@ import ti4.helpers.omegaPhase.PriorityTrackHelper;
 
 class AssignPlayerPriority extends GameStateSubcommand {
     public AssignPlayerPriority() {
-        super(Constants.ASSIGN_PLAYER_PRIORITY, "Assign a player's position on the Priority Track", true, true);
+        super(Constants.ASSIGN_PLAYER_PRIORITY, "Assign a player's position on the Priority Track (use -1 to remove player from track)", true, true);
         addOptions(
-            new OptionData(OptionType.INTEGER, Constants.PRIORITY_POSITION, "Position on priority track (assign -1 to remove them from the track)", true))
+            new OptionData(OptionType.INTEGER, Constants.PRIORITY_POSITION, "Position on priority track (uses lowest available position if not set)"))
                 .addOptions(new OptionData(OptionType.USER, Constants.PLAYER, "Player for which you set stats"))
                 .addOptions(new OptionData(OptionType.STRING, Constants.FACTION_COLOR,
                     "Set stats for another Faction or Color")
@@ -24,13 +24,17 @@ class AssignPlayerPriority extends GameStateSubcommand {
     public void execute(SlashCommandInteractionEvent event) {
         var game = getGame();
         var player = getPlayer();
-        var maxPosition = game.getPlayers().size();
-        var newPosition = event.getOption(Constants.PRIORITY_POSITION, null, OptionMapping::getAsInt);
-        if (newPosition < -1 || newPosition > maxPosition) {
-            MessageHelper.sendMessageToChannel(event.getChannel(), "Priority position must be between 1 and " + maxPosition + ", or -1 to remove them.");
-            return;
+        var positionOption = event.getOption(Constants.PRIORITY_POSITION);
+        Integer specificAssignment = null;
+        if (positionOption != null) {
+            specificAssignment = positionOption.getAsInt();
+            var maxPosition = game.getPlayers().size();
+            if (specificAssignment < -1 || specificAssignment > maxPosition) {
+                MessageHelper.sendMessageToChannel(event.getChannel(), "Priority position must be between 1 and " + maxPosition + ", or -1 to remove them.");
+                return;
+            }
         }
 
-        PriorityTrackHelper.AssignPlayerToPriority(game, player, newPosition);
+        PriorityTrackHelper.AssignPlayerToPriority(game, player, specificAssignment);
     }
 }

--- a/src/main/java/ti4/commands/omegaphase/ClearPriorityTrack.java
+++ b/src/main/java/ti4/commands/omegaphase/ClearPriorityTrack.java
@@ -1,0 +1,17 @@
+package ti4.commands.omegaphase;
+
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import ti4.commands.GameStateSubcommand;
+import ti4.helpers.Constants;
+import ti4.helpers.omegaPhase.PriorityTrackHelper;
+
+class ClearPriorityTrack extends GameStateSubcommand {
+    public ClearPriorityTrack() {
+        super(Constants.CLEAR_PRIORITY_TRACK, "Clear all players off of the Priority Track", true, false);
+    }
+
+    @Override
+    public void execute(SlashCommandInteractionEvent event) {
+        PriorityTrackHelper.ClearPriorityTrack(getGame());
+    }
+}

--- a/src/main/java/ti4/commands/omegaphase/OmegaPhaseCommand.java
+++ b/src/main/java/ti4/commands/omegaphase/OmegaPhaseCommand.java
@@ -11,11 +11,9 @@ import ti4.helpers.Constants;
 public class OmegaPhaseCommand implements ParentCommand {
 
     private final Map<String, Subcommand> subcommands = Stream.of(
-            new AssignPlayerPriority(),
-            new ClearPriorityTrack(),
-            new PrintPriorityTrack()
-    ).collect(Collectors.toMap(Subcommand::getName, subcommand -> subcommand));
-
+        new AssignPlayerPriority(),
+        new ClearPriorityTrack(),
+        new PrintPriorityTrack()).collect(Collectors.toMap(Subcommand::getName, subcommand -> subcommand));
 
     @Override
     public String getName() {

--- a/src/main/java/ti4/commands/omegaphase/OmegaPhaseCommand.java
+++ b/src/main/java/ti4/commands/omegaphase/OmegaPhaseCommand.java
@@ -1,0 +1,34 @@
+package ti4.commands.omegaphase;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import ti4.commands.ParentCommand;
+import ti4.commands.Subcommand;
+import ti4.helpers.Constants;
+
+public class OmegaPhaseCommand implements ParentCommand {
+
+    private final Map<String, Subcommand> subcommands = Stream.of(
+            new AssignPlayerPriority(),
+            new ClearPriorityTrack(),
+            new PrintPriorityTrack()
+    ).collect(Collectors.toMap(Subcommand::getName, subcommand -> subcommand));
+
+
+    @Override
+    public String getName() {
+        return Constants.OMEGA_PHASE_COMMAND;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Omega Phase homebrew commands";
+    }
+
+    @Override
+    public Map<String, Subcommand> getSubcommands() {
+        return subcommands;
+    }
+}

--- a/src/main/java/ti4/commands/omegaphase/PrintPriorityTrack.java
+++ b/src/main/java/ti4/commands/omegaphase/PrintPriorityTrack.java
@@ -1,0 +1,17 @@
+package ti4.commands.omegaphase;
+
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import ti4.commands.GameStateSubcommand;
+import ti4.helpers.Constants;
+import ti4.helpers.omegaPhase.PriorityTrackHelper;
+
+class PrintPriorityTrack extends GameStateSubcommand {
+    public PrintPriorityTrack() {
+        super(Constants.PRINT_PRIORITY_TRACK, "Print the current Priority Track", false, false);
+    }
+
+    @Override
+    public void execute(SlashCommandInteractionEvent event) {
+        PriorityTrackHelper.PrintPriorityTrack(getGame());
+    }
+}

--- a/src/main/java/ti4/helpers/Constants.java
+++ b/src/main/java/ti4/helpers/Constants.java
@@ -710,6 +710,19 @@ public class Constants {
     public static final String PEEK_AT_STAGE1 = "peek_at_stage1";
     public static final String PEEK_AT_STAGE2 = "peek_at_stage2";
 
+    //Omega Phase bot commands and parameters
+    public static final String OMEGA_PHASE_COMMAND = "omegaphase";
+    public static final String SETUP_VOTC = "setup_voice_of_the_council";
+    public static final String ASSIGN_PLAYER_TO_VOTC = "assign_player_to_votc";
+    public static final String ASSIGN_PLAYER_PRIORITY = "assign_player_priority";
+    public static final String CLEAR_PRIORITY_TRACK = "clear_priority_track";
+    public static final String PRINT_PRIORITY_TRACK = "print_priority_track";
+    public static final String PEEK_AT_NEXT_OBJECTIVE = "peek_at_next_objective";
+    public static final String PRINT_OMEGA_PHASE_RULES = "print_omega_phase_rules";
+    public static final String PRIORITY_POSITION = "priority_position";
+    //Omega Phase state keys
+    public static final String PRIORITY_TRACK = "priority_track";
+
     public static final String ADD_CUSTOM = "po_add_custom";
     public static final String MAKE_SO_INTO_PO = "so_into_po";
     public static final String SO_TO_PO = "so_to_po";

--- a/src/main/java/ti4/helpers/omegaPhase/PriorityTrackHelper.java
+++ b/src/main/java/ti4/helpers/omegaPhase/PriorityTrackHelper.java
@@ -15,9 +15,9 @@ public class PriorityTrackHelper {
             .filter(p -> p.hasPriorityPosition())
             .collect(Collectors.toMap(Player::getPriorityPosition, (player) -> player));
 
-        for(var i = 0; i < players.size(); i++) {
+        for (var i = 0; i < players.size(); i++) {
             int priority = i + 1;
-            if(priorityMap.containsKey(priority)) {
+            if (priorityMap.containsKey(priority)) {
                 var player = priorityMap.get(priority);
                 sb += String.format("%d. %s\n", priority, player.getRepresentation());
             } else {
@@ -33,17 +33,17 @@ public class PriorityTrackHelper {
      * gets priority 2, etc.
      */
     public static void AssignPlayerToPriority(Game game, Player player, int priority) {
-        if(priority < 1) {
-            MessageHelper.sendMessageToChannel(game.getActionsChannel(), "Priority must be a positive integer.");
+        if (priority < -1) {
+            MessageHelper.sendMessageToChannel(game.getActionsChannel(), "Priority must be between 1 and the number of players (or just -1).");
             return;
         }
         var players = game.getPlayers().values();
-        if(priority > players.size()) {
+        if (priority > players.size()) {
             MessageHelper.sendMessageToChannel(game.getActionsChannel(), "Priority cannot exceed the number of players.");
             return;
         }
         // Ensure player exists in the game
-        if(players.stream().noneMatch(p -> p.getUserID() == player.getUserID())) {
+        if (players.stream().noneMatch(p -> p.getUserID() == player.getUserID())) {
             MessageHelper.sendMessageToChannel(game.getActionsChannel(), "Player not found in the game.");
             return;
         }
@@ -54,22 +54,29 @@ public class PriorityTrackHelper {
         var existingIndex = players.stream()
             .filter(p -> p.hasPriorityPosition() && p.getPriorityPosition() == priority)
             .findFirst();
-        if(existingIndex.isPresent()) {
+        if (existingIndex.isPresent()) {
             var existingPlayer = existingIndex.get();
             existingPlayer.setPriorityPosition(-1); // Clear the existing player's priority
             messageOutput += existingPlayer.getRepresentation() + " has been removed from position " + priority + " on the priority track.\n";
         }
 
-        // Assign the player's priority
-        player.setPriorityPosition(priority);
-        messageOutput += player.getRepresentation() + " has been assigned to position " + priority + " on the priority track.";
+        if (priority > 0) {
+            // Assign the player's priority
+            player.setPriorityPosition(priority);
+            messageOutput += player.getRepresentation() + " has been assigned to position " + priority + " on the priority track.";
+        }
+
+        if (messageOutput.isEmpty()) {
+            // If no message was generated, it means the player was to be removed, but was already off the track
+            messageOutput = player.getRepresentation() + " is not on the priority track.";
+        }
 
         MessageHelper.sendMessageToChannel(game.getActionsChannel(), messageOutput);
     }
 
     public static void ClearPriorityTrack(Game game) {
         var players = game.getPlayers().values();
-        for(var player : players) {
+        for (var player : players) {
             player.setPriorityPosition(-1);
         }
 

--- a/src/main/java/ti4/helpers/omegaPhase/PriorityTrackHelper.java
+++ b/src/main/java/ti4/helpers/omegaPhase/PriorityTrackHelper.java
@@ -1,0 +1,90 @@
+package ti4.helpers.omegaPhase;
+
+import java.util.stream.Collectors;
+
+import ti4.map.Game;
+import ti4.map.Player;
+import ti4.message.MessageHelper;
+
+public class PriorityTrackHelper {
+    public static void PrintPriorityTrack(Game game) {
+        var sb = "**Priority Track**\n";
+
+        var players = game.getPlayers().values();
+        var priorityMap = players.stream()
+            .filter(p -> p.hasPriorityPosition())
+            .collect(Collectors.toMap(Player::getPriorityPosition, (player) -> player));
+
+        for(var i = 0; i < players.size(); i++) {
+            int priority = i + 1;
+            if(priorityMap.containsKey(priority)) {
+                var player = priorityMap.get(priority);
+                sb += String.format("%d. %s\n", priority, player.getRepresentation());
+            } else {
+                sb += String.format("%d.\n", priority);
+            }
+        }
+
+        MessageHelper.sendMessageToChannel(game.getActionsChannel(), sb);
+        // Full game player state
+        game.getPlayers().values().stream()
+            .forEach(p -> System.out.println("Player: " + p.getRepresentation() + ", Priority: " + p.getPriorityPosition()));
+    }
+
+    /*
+     * Priority is 1-indexed, so the first player gets priority 1, the second player
+     * gets priority 2, etc.
+     */
+    public static void AssignPlayerToPriority(Game game, Player player, int priority) {
+        // Full game player state
+        System.out.println("Start of AssignPlayerToPriority");
+        game.getPlayers().values().stream()
+            .forEach(p -> System.out.println("Player: " + p.getRepresentation() + ", Priority: " + p.getPriorityPosition()));
+        if(priority < 1) {
+            MessageHelper.sendMessageToChannel(game.getActionsChannel(), "Priority must be a positive integer.");
+            return;
+        }
+        var players = game.getPlayers().values();
+        if(priority > players.size()) {
+            MessageHelper.sendMessageToChannel(game.getActionsChannel(), "Priority cannot exceed the number of players.");
+            return;
+        }
+        // Ensure player exists in the game
+        if(players.stream().noneMatch(p -> p.getUserID() == player.getUserID())) {
+            MessageHelper.sendMessageToChannel(game.getActionsChannel(), "Player not found in the game.");
+            return;
+        }
+        // If another player already has this priority value, clear it
+        var existingIndex = players.stream()
+            .filter(p -> p.hasPriorityPosition() && p.getPriorityPosition() == priority)
+            .findFirst();
+        if(existingIndex.isPresent()) {
+            var existingPlayer = existingIndex.get();
+            existingPlayer.setPriorityPosition(-1); // Clear the existing player's priority
+            MessageHelper.sendMessageToChannel(game.getActionsChannel(),
+                    existingPlayer.getRepresentation() + " has been removed from position " + priority + " on the priority track.");
+        }
+        // Assign the player's priority
+        player.setPriorityPosition(priority);
+        System.out.println("End of AssignPlayerToPriority");
+        System.out.println("Assigned player " + player.getRepresentation() + " to priority " + player.getPriorityPosition());
+        // Full game player state
+        game.getPlayers().values().stream()
+            .forEach(p -> System.out.println("Player: " + p.getRepresentation() + ", Priority: " + p.getPriorityPosition()));
+        MessageHelper.sendMessageToChannel(game.getActionsChannel(),
+                player.getRepresentation() + " has been " + (existingIndex.isPresent() ? "moved" : "added") +
+                        " to position " + priority + " on the priority track.");
+    }
+
+    public static void ClearPriorityTrack(Game game) {
+        var players = game.getPlayers().values();
+        for(var player : players) {
+            player.setPriorityPosition(-1);
+        }
+
+        MessageHelper.sendMessageToChannel(game.getActionsChannel(), "The priority track has been cleared.");
+        // Full game player state
+        game.getPlayers().values().stream()
+            .forEach(p -> System.out.println("Player: " + p.getRepresentation() + ", Priority: " + p.getPriorityPosition()));
+    }
+}

--- a/src/main/java/ti4/helpers/omegaPhase/PriorityTrackHelper.java
+++ b/src/main/java/ti4/helpers/omegaPhase/PriorityTrackHelper.java
@@ -12,15 +12,11 @@ public class PriorityTrackHelper {
     public static void PrintPriorityTrack(Game game) {
         var sb = "**Priority Track**\n";
 
-        var players = game.getPlayers().values();
-        var priorityMap = players.stream()
-            .filter(p -> p.hasPriorityPosition())
-            .collect(Collectors.toMap(Player::getPriorityPosition, (player) -> player));
-
-        for (var i = 0; i < players.size(); i++) {
+        var priorityTrack = GetPriorityTrack(game);
+        for (var i = 0; i < priorityTrack.size(); i++) {
             int priority = i + 1;
-            if (priorityMap.containsKey(priority)) {
-                var player = priorityMap.get(priority);
+            if (priorityTrack.get(i) != null) {
+                var player = priorityTrack.get(i);
                 sb += String.format("%d. %s\n", priority, player.getRepresentation());
             } else {
                 sb += String.format("%d.\n", priority);
@@ -71,7 +67,14 @@ public class PriorityTrackHelper {
                 }
             }
         } else {
-            var currentPriotityTrack = getPriorityTrack(game);
+            if (player.hasPriorityPosition()) {
+                // If the player already has a priority position, we don't need to assign them again
+                messageOutput += player.getRepresentation() + " is already on the priority track at position " + player.getPriorityPosition() + ".\n";
+                MessageHelper.sendMessageToChannel(game.getActionsChannel(), messageOutput);
+                return;
+            }
+
+            var currentPriotityTrack = GetPriorityTrack(game);
             for (var i = 0; i < currentPriotityTrack.size(); i++) {
                 if (currentPriotityTrack.get(i) == null) {
                     // Found an empty spot, assign the player here
@@ -81,7 +84,7 @@ public class PriorityTrackHelper {
             }
             if (priority == null) {
                 // If no empty spot was found, return early with message
-                player.setPriorityPosition(-1);
+                player.setPriorityPosition(-1); // Ensure data model matches inferred state
                 messageOutput += player.getRepresentation() + " could not be placed on the priority track because no empty spot was availble.\n";
                 MessageHelper.sendMessageToChannel(game.getActionsChannel(), messageOutput);
                 return;
@@ -113,7 +116,7 @@ public class PriorityTrackHelper {
         MessageHelper.sendMessageToChannel(game.getActionsChannel(), "The priority track has been cleared.");
     }
 
-    public static List<Player> getPriorityTrack(Game game) {
+    public static List<Player> GetPriorityTrack(Game game) {
         List<Player> priorityTrack = new ArrayList<>();
         int numPlayers = game.getPlayers().size();
         for (int i = 0; i < numPlayers; i++) {

--- a/src/main/java/ti4/helpers/omegaPhase/PriorityTrackHelper.java
+++ b/src/main/java/ti4/helpers/omegaPhase/PriorityTrackHelper.java
@@ -26,9 +26,6 @@ public class PriorityTrackHelper {
         }
 
         MessageHelper.sendMessageToChannel(game.getActionsChannel(), sb);
-        // Full game player state
-        game.getPlayers().values().stream()
-            .forEach(p -> System.out.println("Player: " + p.getRepresentation() + ", Priority: " + p.getPriorityPosition()));
     }
 
     /*
@@ -36,10 +33,6 @@ public class PriorityTrackHelper {
      * gets priority 2, etc.
      */
     public static void AssignPlayerToPriority(Game game, Player player, int priority) {
-        // Full game player state
-        System.out.println("Start of AssignPlayerToPriority");
-        game.getPlayers().values().stream()
-            .forEach(p -> System.out.println("Player: " + p.getRepresentation() + ", Priority: " + p.getPriorityPosition()));
         if(priority < 1) {
             MessageHelper.sendMessageToChannel(game.getActionsChannel(), "Priority must be a positive integer.");
             return;
@@ -54,6 +47,9 @@ public class PriorityTrackHelper {
             MessageHelper.sendMessageToChannel(game.getActionsChannel(), "Player not found in the game.");
             return;
         }
+
+        var messageOutput = "";
+
         // If another player already has this priority value, clear it
         var existingIndex = players.stream()
             .filter(p -> p.hasPriorityPosition() && p.getPriorityPosition() == priority)
@@ -61,19 +57,14 @@ public class PriorityTrackHelper {
         if(existingIndex.isPresent()) {
             var existingPlayer = existingIndex.get();
             existingPlayer.setPriorityPosition(-1); // Clear the existing player's priority
-            MessageHelper.sendMessageToChannel(game.getActionsChannel(),
-                    existingPlayer.getRepresentation() + " has been removed from position " + priority + " on the priority track.");
+            messageOutput += existingPlayer.getRepresentation() + " has been removed from position " + priority + " on the priority track.\n";
         }
+
         // Assign the player's priority
         player.setPriorityPosition(priority);
-        System.out.println("End of AssignPlayerToPriority");
-        System.out.println("Assigned player " + player.getRepresentation() + " to priority " + player.getPriorityPosition());
-        // Full game player state
-        game.getPlayers().values().stream()
-            .forEach(p -> System.out.println("Player: " + p.getRepresentation() + ", Priority: " + p.getPriorityPosition()));
-        MessageHelper.sendMessageToChannel(game.getActionsChannel(),
-                player.getRepresentation() + " has been " + (existingIndex.isPresent() ? "moved" : "added") +
-                        " to position " + priority + " on the priority track.");
+        messageOutput += player.getRepresentation() + " has been assigned to position " + priority + " on the priority track.";
+
+        MessageHelper.sendMessageToChannel(game.getActionsChannel(), messageOutput);
     }
 
     public static void ClearPriorityTrack(Game game) {
@@ -83,8 +74,5 @@ public class PriorityTrackHelper {
         }
 
         MessageHelper.sendMessageToChannel(game.getActionsChannel(), "The priority track has been cleared.");
-        // Full game player state
-        game.getPlayers().values().stream()
-            .forEach(p -> System.out.println("Player: " + p.getRepresentation() + ", Priority: " + p.getPriorityPosition()));
     }
 }

--- a/src/main/java/ti4/map/Player.java
+++ b/src/main/java/ti4/map/Player.java
@@ -2502,4 +2502,9 @@ public class Player extends PlayerProperties {
     public boolean isGM() {
         return getGame().getPlayersWithGMRole().contains(this);
     }
+
+    @JsonIgnore
+    public boolean hasPriorityPosition() {
+        return this.getPriorityPosition() != -1 && this.getPriorityPosition() != 0;
+    }
 }

--- a/src/main/java/ti4/map/manage/GameLoadService.java
+++ b/src/main/java/ti4/map/manage/GameLoadService.java
@@ -38,6 +38,7 @@ import ti4.helpers.AliasHandler;
 import ti4.helpers.Constants;
 import ti4.helpers.DisplayType;
 import ti4.helpers.Helper;
+import ti4.helpers.omegaPhase.PriorityTrackHelper;
 import ti4.helpers.Storage;
 import ti4.helpers.TIGLHelper;
 import ti4.helpers.Units;
@@ -1054,6 +1055,7 @@ class GameLoadService {
                     TIGLHelper.TIGLRank rank = TIGLHelper.TIGLRank.fromString(rankID);
                     player.setPlayerTIGLRankAtGameStart(rank);
                 }
+                case Constants.PRIORITY_TRACK -> player.setPriorityPosition(Integer.parseInt(tokenizer.nextToken()));
             }
         }
     }

--- a/src/main/java/ti4/map/manage/GameSaveService.java
+++ b/src/main/java/ti4/map/manage/GameSaveService.java
@@ -797,7 +797,7 @@ class GameSaveService {
             }
 
             if(player.hasPriorityPosition()) {
-                writer.write(Constants.PRIORITY_POSITION + " " + player.getPriorityPosition());
+                writer.write(Constants.PRIORITY_TRACK + " " + player.getPriorityPosition());
                 writer.write(System.lineSeparator());
             }
 

--- a/src/main/java/ti4/map/manage/GameSaveService.java
+++ b/src/main/java/ti4/map/manage/GameSaveService.java
@@ -21,6 +21,7 @@ import ti4.helpers.DisplayType;
 import ti4.helpers.FoWHelper;
 import ti4.helpers.Storage;
 import ti4.helpers.Units.UnitKey;
+import ti4.helpers.omegaPhase.PriorityTrackHelper;
 import ti4.helpers.settingsFramework.menus.MiltySettings;
 import ti4.image.Mapper;
 import ti4.json.ObjectMapperFactory;
@@ -792,6 +793,11 @@ class GameSaveService {
 
             if (player.getPlayerTIGLRankAtGameStart() != null) {
                 writer.write(Constants.TIGL_RANK + " " + player.getPlayerTIGLRankAtGameStart());
+                writer.write(System.lineSeparator());
+            }
+
+            if(player.hasPriorityPosition()) {
+                writer.write(Constants.PRIORITY_POSITION + " " + player.getPriorityPosition());
                 writer.write(System.lineSeparator());
             }
 

--- a/src/main/java/ti4/map/manage/GameSaveService.java
+++ b/src/main/java/ti4/map/manage/GameSaveService.java
@@ -796,7 +796,7 @@ class GameSaveService {
                 writer.write(System.lineSeparator());
             }
 
-            if(player.hasPriorityPosition()) {
+            if (player.hasPriorityPosition()) {
                 writer.write(Constants.PRIORITY_TRACK + " " + player.getPriorityPosition());
                 writer.write(System.lineSeparator());
             }

--- a/src/main/java/ti4/map/pojo/PlayerProperties.java
+++ b/src/main/java/ti4/map/pojo/PlayerProperties.java
@@ -81,6 +81,9 @@ public class PlayerProperties {
     private int sarweenCounter;
     private int pillageCounter;
 
+    //Omega Phase
+    private int priorityPosition;
+
     // OLRADIN POLICY ONCE PER ACTION EXHAUST PLANET ABILITIES
     private boolean hasUsedEconomyEmpowerAbility;
     private boolean hasUsedEconomyExploitAbility;


### PR DESCRIPTION
Simple priority track. Stored by player position, on each player object.

## Model

`private int playerPosition;` on PlayerProperties.java

Possible positions:
-1 is unassigned
0 is a default int, also unassigned
1 <= N <= Max # of players: actual positions on the track.

## Bot Commands

- Assign Player to Priority Track Position:
    - After a player passes, use this without parameters to assign them to the lowest available position on the track
    - Extra utility options: Assign player to specific position, or remove just them from the track
- Print Priority Track:
    - At the start of the Strategy Phase, use this to see the order to pick cards
- Clear Priority Track:
    - At the end of the Strategy Phase, use this to reset the Priority Track for the upcoming Action Phase