### PR TITLE
Map and Banner updates

### DIFF
--- a/src/main/java/ti4/helpers/AgendaHelper.java
+++ b/src/main/java/ti4/helpers/AgendaHelper.java
@@ -3288,7 +3288,7 @@ public class AgendaHelper {
             aCount = Integer.parseInt(agendaCount) + 1;
         }
         game.setStoredValue("agendaCount", aCount + "");
-        if (aCount == 1 && game.isShowBanners()) {
+        if (aCount == 1 && game.isShowBanners() && !game.isOmegaPhaseMode()) {
             BannerGenerator.drawPhaseBanner("agenda", game.getRound(), game.getActionsChannel());
         }
 

--- a/src/main/java/ti4/helpers/StatusHelper.java
+++ b/src/main/java/ti4/helpers/StatusHelper.java
@@ -39,7 +39,7 @@ public class StatusHelper {
     public static void AnnounceStatusPhase(Game game) {
         MessageHelper.sendMessageToChannel(game.getMainGameChannel(), "All players have passed.");
         if (game.isShowBanners()) {
-            BannerGenerator.drawPhaseBanner("status", game.getRound(), game.getActionsChannel());
+            BannerGenerator.drawPhaseBanner("status", game.getRound(), game.getActionsChannel(), game.isOmegaPhaseMode() ? "omega" : null);
         }
     }
 
@@ -328,7 +328,7 @@ public class StatusHelper {
             if (po_name == null) {
                 Integer integer = customPublicVP.get(key);
                 if (integer != null && !key.toLowerCase().contains("custodian") && !key.toLowerCase().contains("imperial")
-                    && !key.contains("Shard of the Throne")) {
+                    && !key.contains("Shard of the Throne") && !key.contains(Constants.VOICE_OF_THE_COUNCIL_PO)) {
                     po_name = key;
                     poStatus = 2;
                 }

--- a/src/main/java/ti4/image/BannerGenerator.java
+++ b/src/main/java/ti4/image/BannerGenerator.java
@@ -84,6 +84,13 @@ public class BannerGenerator {
     }
 
     public static void drawPhaseBanner(String phase, int round, TextChannel channel) {
+        drawPhaseBanner(phase, round, channel, null);
+    }
+
+    public static void drawPhaseBanner(String phase, int round, TextChannel channel, String altPhaseName) {
+        if (altPhaseName == null) {
+            altPhaseName = phase;
+        }
         BufferedImage bannerImage = new BufferedImage(511, 331, BufferedImage.TYPE_INT_ARGB);
         BufferedImage backgroundImage = ImageHelper.readScaled(ResourceHelper.getInstance().getExtraFile(phase + "banner.png"), 511, 331);
 
@@ -91,13 +98,13 @@ public class BannerGenerator {
         bannerG.drawImage(backgroundImage, 0, 0, null);
         bannerG.setFont(Storage.getFont48());
         bannerG.setColor(Color.WHITE);
-        DrawingUtil.superDrawString(bannerG, phase.toUpperCase() + " PHASE", 255, 110, Color.WHITE, MapGenerator.HorizontalAlign.Center, MapGenerator.VerticalAlign.Center, stroke8, Color.BLACK);
+        DrawingUtil.superDrawString(bannerG, altPhaseName.toUpperCase() + " PHASE", 255, 110, Color.WHITE, MapGenerator.HorizontalAlign.Center, MapGenerator.VerticalAlign.Center, stroke8, Color.BLACK);
         bannerG.setFont(Storage.getFont32());
 
         String roundText = "ROUND " + StringHelper.numberToWords(round).toUpperCase();
         DrawingUtil.superDrawString(bannerG, roundText, 255, 221, Color.WHITE, MapGenerator.HorizontalAlign.Center, MapGenerator.VerticalAlign.Center, stroke6, Color.BLACK);
 
-        String descr = "Start of " + phase + " phase, round " + round + ".";
+        String descr = "Start of " + altPhaseName + " phase, round " + round + ".";
         FileUpload fileUpload = FileUploadService.createFileUpload(bannerImage, phase + round + "banner").setDescription(descr);
         MessageHelper.sendFileUploadToChannel(channel, fileUpload);
     }


### PR DESCRIPTION
Add an alternative phase name for the banner (to support "Omega Phase"), and also hide the Agenda Phase banner for `game.isOmegaPhaseMode()`.

More significantly, the map updates: Render the Priority Track and split the 10 stage 1 objectives into two columns. Definitely interested if there are any design/architectural issues I'm unaware of. Borrowed heavily from `drawScoreTrack`

## Omega Phase game rendering:
![image](https://github.com/user-attachments/assets/909859d5-e892-44e4-b22f-fde6b6bff746)


## Non-Omega Phase game rendering (should be unchanged):
![image](https://github.com/user-attachments/assets/6c93ce9e-ddae-435c-ac29-9cca6eb804f2)

## Example of banner

![image](https://github.com/user-attachments/assets/b4346de9-4fc0-4ce5-8b01-d2fade3d299e)

